### PR TITLE
Fix: Correct invalid 'fields' parameter in Quran.com API request

### DIFF
--- a/convex/quran.ts
+++ b/convex/quran.ts
@@ -15,7 +15,7 @@ export const getPageData = action({
     
     try {
       // Build the API URL with proper parameters
-      const url = `https://api.quran.com/api/v4/verses/by_page/${pageNumber}?language=ar&words=false&translations=${translationId}&tafsirs=${tafsirId}&audio=${reciterId}&fields=text_uthmani,chapter_id,verse_number,verse_key,juz_number,hizb_number,rub_number,page_number,audio,tafsirs,translations`;
+      const url = `https://api.quran.com/api/v4/verses/by_page/${pageNumber}?language=ar&words=false&translations=${translationId}&tafsirs=${tafsirId}&audio=${reciterId}&fields=text_uthmani,chapter_id,verse_number,verse_key,juz_number,hizb_number,rub_number,page_number`;
       
       console.log("Fetching from URL:", url);
       


### PR DESCRIPTION
This commit fixes a server error that occurred after the initial data flow refactor. The `getPageData` action was crashing because the `fields` query parameter in the `api.quran.com` request contained invalid keys (`audio`, `tafsirs`, `translations`).

The fix removes these keys from the `fields` parameter. The presence of the `audio`, `tafsirs`, and `translations` parameters in the URL is sufficient to have the API include these objects in the response.

This change ensures the API call is successful and that the application can correctly fetch and display all page data.