### PR TITLE
Fix: Resolve server error by correcting default translation ID and da…

### DIFF
--- a/convex/quran.ts
+++ b/convex/quran.ts
@@ -11,7 +11,7 @@ export const getPageData = action({
     translationId: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const { pageNumber, reciterId = 7, tafsirId = 167, translationId = 131 } = args;
+    const { pageNumber, reciterId = 7, tafsirId = 167, translationId = 20 } = args;
     
     try {
       // Build the API URL with proper parameters
@@ -48,7 +48,9 @@ export const getPageData = action({
         juz_number: verse.juz_number || 1,
         hizb_number: verse.hizb_number || 1,
         rub_number: verse.rub_number || 1,
-        audio: verse.audio || null
+        audio: verse.audio || null,
+        translations: verse.translations || [],
+        tafsirs: verse.tafsirs || [],
       }));
       
       return {
@@ -188,7 +190,7 @@ export const getUserPreferences = query({
     return prefs || {
       selectedReciter: 7, // Default to Al-Afasy
       selectedTafsir: 167, // Default to Jalalayn
-      selectedTranslation: 131, // Default to Sahih International
+      selectedTranslation: 20, // Default to Sahih International
       theme: "light",
       fontSize: "medium",
       arabicFont: "uthmani",
@@ -227,7 +229,7 @@ export const updateUserPreferences = mutation({
         userId,
         selectedReciter: 7,
         selectedTafsir: 167,
-        selectedTranslation: 131,
+        selectedTranslation: 20,
         theme: "light",
         fontSize: "medium",
         arabicFont: "uthmani",

--- a/src/components/QuranReader.tsx
+++ b/src/components/QuranReader.tsx
@@ -65,7 +65,7 @@ export function QuranReader() {
         pageNumber,
         reciterId: userPreferences?.selectedReciter || 7,
         tafsirId: userPreferences?.selectedTafsir || 167,
-        translationId: userPreferences?.selectedTranslation || 131,
+        translationId: userPreferences?.selectedTranslation || 20,
       });
       
       console.log("Page data loaded:", data);

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -14,7 +14,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
   const [settings, setSettings] = useState({
     selectedReciter: 7,
     selectedTafsir: 167,
-    selectedTranslation: 131,
+    selectedTranslation: 20,
     theme: "light",
     fontSize: "medium",
     arabicFont: "uthmani",
@@ -29,7 +29,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
       setSettings({
         selectedReciter: userPreferences.selectedReciter || 7,
         selectedTafsir: userPreferences.selectedTafsir || 167,
-        selectedTranslation: userPreferences.selectedTranslation || 131,
+        selectedTranslation: userPreferences.selectedTranslation || 20,
         theme: userPreferences.theme || "light",
         fontSize: userPreferences.fontSize || "medium",
         arabicFont: userPreferences.arabicFont || "uthmani",
@@ -71,13 +71,13 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
   ];
 
   const translations = [
-    { id: 131, name: "مجمع الملك فهد (إنجليزية)" },
-    { id: 20, name: "صحيح الدولية" },
+    { id: 20, name: "صحيح الدولية (إنجليزية)" },
     { id: 84, name: "تقي عثماني (إنجليزية)" },
     { id: 31, name: "محمد حميد الله (فرنسية)" },
     { id: 83, name: "الشيخ عيسى غارسيا (إسبانية)" },
     { id: 77, name: "ترجمة ديانت (تركية)" },
-    { id: 33, name: "وزارة الشؤون الإسلامية الإندونيسية" },
+    { id: 33, name: "وزارة الشؤون الإسلامية (إندونيسية)" },
+    { id: 131, name: "عبدالله أبوبكر (سواحيلية)" },
   ];
 
   return (


### PR DESCRIPTION
…ta processing

This commit addresses a recurring server error in the `getPageData` action. The root cause was twofold:
1. The default translation ID was set to `131`, which appears to be an invalid or unsupported ID for the `verses/by_page` API endpoint, causing the external API to fail.
2. A latent bug in the data processing logic was discarding the `translations` and `tafsirs` fields after they were fetched.

The fix includes:
- Changing the default translation ID to `20` (Saheeh International) across the entire application (`convex/quran.ts`, `QuranReader.tsx`, `SettingsPanel.tsx`).
- Correcting the `processedVerses` mapping in `convex/quran.ts` to ensure `translations` and `tafsirs` are passed to the frontend.

These changes should resolve the server error and ensure all features work correctly.