### PR TITLE
fix(convex): Include translations and tafsirs in API request

### DIFF
--- a/convex/quran.ts
+++ b/convex/quran.ts
@@ -15,7 +15,7 @@ export const getPageData = action({
     
     try {
       // Build the API URL with proper parameters
-      const url = `https://api.quran.com/api/v4/verses/by_page/${pageNumber}?language=ar&words=false&translations=${translationId}&tafsirs=${tafsirId}&audio=${reciterId}&fields=text_uthmani,chapter_id,verse_number,verse_key,juz_number,hizb_number,rub_number,page_number`;
+      const url = `https://api.quran.com/api/v4/verses/by_page/${pageNumber}?language=ar&words=false&translations=${translationId}&tafsirs=${tafsirId}&audio=${reciterId}&fields=text_uthmani,chapter_id,verse_number,verse_key,juz_number,hizb_number,rub_number,page_number,translations,tafsirs`;
       
       console.log("Fetching from URL:", url);
       


### PR DESCRIPTION
The `getPageData` action was failing because the API call to quran.com was not requesting the `translations` and `tafsirs` fields. This caused a server-side error in the Convex action when the client-side code tried to access this data.

This change adds `translations` and `tafsirs` to the `fields` parameter of the API request to ensure the data is returned.