### PR TITLE
Debug: Simplify getPageData API call to isolate server error

### DIFF
--- a/convex/quran.ts
+++ b/convex/quran.ts
@@ -14,10 +14,10 @@ export const getPageData = action({
     const { pageNumber, reciterId = 7, tafsirId = 167, translationId = 20 } = args;
     
     try {
-      // Build the API URL with proper parameters
-      const url = `https://api.quran.com/api/v4/verses/by_page/${pageNumber}?language=ar&words=false&translations=${translationId}&tafsirs=${tafsirId}&audio=${reciterId}&fields=text_uthmani,chapter_id,verse_number,verse_key,juz_number,hizb_number,rub_number,page_number`;
+      // Build the API URL with only the essential parameters for debugging
+      const url = `https://api.quran.com/api/v4/verses/by_page/${pageNumber}?language=ar&words=false&fields=text_uthmani,chapter_id,verse_number,verse_key,juz_number,hizb_number,rub_number,page_number`;
       
-      console.log("Fetching from URL:", url);
+      console.log("Fetching from URL (minimal for debugging):", url);
       
       const response = await fetch(url, {
         headers: {

--- a/convex/quran.ts
+++ b/convex/quran.ts
@@ -15,9 +15,9 @@ export const getPageData = action({
     
     try {
       // Build the API URL with only the essential parameters for debugging
-      const url = `https://api.quran.com/api/v4/verses/by_page/${pageNumber}?language=ar&words=false&fields=text_uthmani,chapter_id,verse_number,verse_key,juz_number,hizb_number,rub_number,page_number`;
+      const url = `https://api.quran.com/api/v4/verses/by_page/${pageNumber}?language=ar&words=false`;
       
-      console.log("Fetching from URL (minimal for debugging):", url);
+      console.log("Fetching from URL (ultra-minimal for debugging):", url);
       
       const response = await fetch(url, {
         headers: {


### PR DESCRIPTION
This commit is a debugging step to isolate a recurring server error. The `getPageData` action is simplified to make the most basic possible API call to `api.quran.com`, fetching only the verse text without any optional data like audio, tafsirs, or translations.

The purpose of this change is to establish a working baseline. If this commit resolves the server error, it proves the issue lies with one of the optional parameters, which can then be added back one by one to find the culprit.