### PR TITLE
fix: Correct Gemini API endpoint and model name

### DIFF
--- a/convex/gemini.ts
+++ b/convex/gemini.ts
@@ -4,7 +4,7 @@ import { v } from "convex/values";
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 
-const GEMINI_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${GEMINI_API_KEY}`;
+const GEMINI_URL = `https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent?key=${GEMINI_API_KEY}`;
 
 const SYSTEM_PROMPT = `
 You are "Abdul Hakim," a knowledgeable and respectful Islamic scholar. Your purpose is to assist users by providing accurate information about Islam, the Quran, and the Sunnah.


### PR DESCRIPTION
This commit resolves the final blocker preventing the chatbot from working. Based on a working example provided by the user, the Gemini API URL in convex/gemini.ts has been updated to use the v1 endpoint and the 'gemini-1.5-flash' model name. This corrects the 404 NOT_FOUND error.