### PR TITLE
chore: Force new commit to trigger deployment

### DIFF
--- a/convex/gemini.ts
+++ b/convex/gemini.ts
@@ -1,3 +1,4 @@
+// Forcing a new commit to trigger a fresh deployment.
 "use client";
 import { action } from "./_generated/server";
 import { v } from "convex/values";


### PR DESCRIPTION
Added a trivial comment to force a new commit hash. This is intended to re-trigger the GitHub Actions and Netlify deployment pipeline, ensuring the latest correct code is deployed.