### PR TITLE
fix: Polish UI with control-linked chat icon and improved layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { type Verse } from "./lib/types";
 export default function App() {
   const [isChatOpen, setIsChatOpen] = useState(false);
   const [verseToAsk, setVerseToAsk] = useState<Verse | null>(null);
+  const [showControls, setShowControls] = useState(true);
 
   const handleAskAi = (verse: Verse) => {
     setVerseToAsk(verse);
@@ -16,17 +17,24 @@ export default function App() {
 
   const handleCloseChat = () => {
     setIsChatOpen(false);
-    // Delay clearing the verse to allow for closing animation
     setTimeout(() => {
       setVerseToAsk(null);
     }, 300);
   };
 
+  const handlePageClick = () => {
+    setShowControls(prev => !prev);
+  };
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <QuranReader onAskAi={handleAskAi} />
+      <QuranReader
+        onAskAi={handleAskAi}
+        showControls={showControls}
+        onPageClick={handlePageClick}
+      />
       
-      {!isChatOpen && (
+      {!isChatOpen && showControls && (
         <button
           onClick={() => setIsChatOpen(true)}
           className="fixed bottom-20 right-4 z-40 p-3 bg-blue-600 text-white rounded-full shadow-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-transform hover:scale-110"

--- a/src/components/QuranPage.tsx
+++ b/src/components/QuranPage.tsx
@@ -208,9 +208,9 @@ export function QuranPage({ verses, isLoading, currentPage, userPreferences, pla
             />
           ))
         ) : (
-          <div className={`${fontFamilyClasses[arabicFont]} text-2xl leading-loose text-justify text-main`} dir="rtl" style={{ textAlignLast: 'center' }}>
+          <div className={`${fontFamilyClasses[arabicFont]} text-3xl leading-relaxed text-right text-main p-4`} dir="rtl">
             {verses.map((verse, index) => (
-              <span key={verse.id || index} className={`cursor-pointer bg-hover rounded px-1 transition-colors duration-200 ${highlightedVerse === verse.verse_key ? 'active-verse' : ''}`} onClick={(e) => handleVerseClick(verse, e)}>
+              <span key={verse.id || index} className={`cursor-pointer hover:bg-hover rounded px-1 transition-colors duration-200 ${highlightedVerse === verse.verse_key ? 'active-verse' : ''}`} onClick={(e) => handleVerseClick(verse, e)}>
                 {verse.text_uthmani || "نص الآية غير متوفر"}
                 <span className="verse-number">{verse.verse_number}</span>
                 {index < verses.length - 1 && " "}

--- a/src/components/QuranReader.tsx
+++ b/src/components/QuranReader.tsx
@@ -24,12 +24,17 @@ interface PageData {
   meta?: any;
 }
 
-export function QuranReader({ onAskAi }: { onAskAi: (verse: Verse) => void }) {
+interface QuranReaderProps {
+  onAskAi: (verse: Verse) => void;
+  showControls: boolean;
+  onPageClick: () => void;
+}
+
+export function QuranReader({ onAskAi, showControls, onPageClick }: QuranReaderProps) {
   const [currentPage, setCurrentPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
   const [pageData, setPageData] = useState<PageData | null>(null);
   const [audioPlaylist, setAudioPlaylist] = useState<any[]>([]);
-  const [showControls, setShowControls] = useState(true);
   const [activePanel, setActivePanel] = useState<string | null>(null);
   const [showSettingsPage, setShowSettingsPage] = useState(false);
   const [touchStart, setTouchStart] = useState<number | null>(null);
@@ -178,10 +183,6 @@ export function QuranReader({ onAskAi }: { onAskAi: (verse: Verse) => void }) {
     if (distance < -50 && currentPage > 1) {
       loadPage(currentPage - 1, { shouldStartPlaying: false });
     }
-  };
-
-  const handlePageClick = () => {
-    setShowControls(prev => !prev);
   };
 
   const goToNextPage = () => {
@@ -336,7 +337,7 @@ export function QuranReader({ onAskAi }: { onAskAi: (verse: Verse) => void }) {
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
-        onClick={handlePageClick}
+        onClick={onPageClick}
       >
         <div className="py-6">
           <QuranPage


### PR DESCRIPTION
This commit applies the final set of UI polishing based on user feedback.

- **Hides Chat Icon with Controls:** The floating chat icon's visibility is now linked to the main UI controls. It disappears when the user clicks on the page content to hide the header and footer, providing a cleaner reading experience. This was achieved by lifting the 'showControls' state to the main App component.
- **Improves Verse Layout:** The continuous "flow" layout for verses has been improved with right-alignment and better line-height for a more organized, book-like appearance.