### PR TITLE
fix: Correct settings page logic and apply font size to all layouts

### DIFF
--- a/src/components/QuranPage.tsx
+++ b/src/components/QuranPage.tsx
@@ -208,7 +208,7 @@ export function QuranPage({ verses, isLoading, currentPage, userPreferences, pla
             />
           ))
         ) : (
-          <div className={`${fontFamilyClasses[arabicFont]} text-3xl leading-loose text-justify text-main p-4`} dir="rtl">
+          <div className={`${fontFamilyClasses[arabicFont]} ${fontSizeClasses[fontSize]} leading-loose text-justify text-main p-4`} dir="rtl">
             {verses.map((verse, index) => (
               <span key={verse.id || index} className={`cursor-pointer hover:bg-hover rounded px-1 transition-colors duration-200 ${highlightedVerse === verse.verse_key ? 'active-verse' : ''}`} onClick={(e) => handleVerseClick(verse, e)}>
                 {verse.text_uthmani || "نص الآية غير متوفر"}


### PR DESCRIPTION
This commit fixes several UI and state management bugs based on user feedback.

- **Restores Settings Page Logic:** The logic for fetching tafsirs and translations, which was accidentally removed, has been restored. The "Save" functionality is now fully operational again, and the font size setting applies instantly for better UX.
- **Fixes Font Size Application:** The font size selection now correctly applies to both the "list" and "flow" verse layouts, not just the list view.
- **Improves Justification:** The verse layout now uses `text-align: justify` for a more book-like appearance.