### PR TITLE
This commit addresses two critical bugs in the settings functionality.

### DIFF
--- a/src/components/QuranReader.tsx
+++ b/src/components/QuranReader.tsx
@@ -150,6 +150,8 @@ export function QuranReader({ onAskAi, showControls, onPageClick }: QuranReaderP
     root.classList.add(`theme-${currentTheme}`);
   }, [currentTheme]);
   
+  const isInitialMount = useRef(true);
+
   useEffect(() => {
     const initializeApp = async () => {
       const savedPage = localStorage.getItem('quranLastPage');
@@ -160,10 +162,14 @@ export function QuranReader({ onAskAi, showControls, onPageClick }: QuranReaderP
   }, []);
 
   useEffect(() => {
-    if (userPreferences && currentPage > 0 && pageData) {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    if (currentPage > 0) {
       loadPage(currentPage, { shouldStartPlaying: false });
     }
-  }, [userPreferences?.selectedReciter, userPreferences?.selectedTafsir]);
+  }, [selectedReciter, selectedTafsir, selectedTranslation]);
 
   const handleTouchStart = (e: React.TouchEvent) => {
     setTouchEnd(null);

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useQuery, useMutation, useAction } from "convex/react";
+import { useConvexAuth, useQuery, useMutation, useAction } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { toast } from "sonner";
 import { Moon, Save, X, Leaf, BookOpen, Sun } from "lucide-react";
@@ -38,6 +38,7 @@ export function SettingsPage({
   setCurrentTheme,
   setArabicFont,
 }: SettingsPageProps) {
+  const { isAuthenticated } = useConvexAuth();
   const [isModified, setIsModified] = useState(false);
   const [localReciter, setLocalReciter] = useState(selectedReciter);
   const [localTafsir, setLocalTafsir] = useState(selectedTafsir);
@@ -90,6 +91,12 @@ export function SettingsPage({
     setIsModified(true);
   };
 
+  const handleThemeChange = (theme: string) => {
+    setLocalTheme(theme);
+    setCurrentTheme(theme); // Apply theme instantly
+    setIsModified(true);
+  };
+
   const saveAllSettings = async () => {
     setSelectedReciter(localReciter);
     setSelectedTafsir(localTafsir);
@@ -108,9 +115,10 @@ export function SettingsPage({
     };
 
     try {
-      await updatePreferences(settingsToSave);
+      if (isAuthenticated) {
+        await updatePreferences(settingsToSave);
+      }
       localStorage.setItem('quranSettings', JSON.stringify(settingsToSave));
-      await loadPage();
       setIsModified(false);
       toast.success("تم حفظ الإعدادات بنجاح");
       onClose();
@@ -175,16 +183,16 @@ export function SettingsPage({
           <div>
             <label className="block text-sm font-medium text-muted mb-2">المظهر</label>
             <div className="grid grid-cols-4 gap-3 mt-2">
-              <button onClick={() => handleGenericChange(setCurrentTheme, 'light')} className={`flex flex-col items-center justify-center p-3 rounded-lg transition-all ${localTheme === 'light' ? 'bg-accent text-white ring-2 ring-accent' : 'bg-hover'}`}>
+              <button onClick={() => handleThemeChange('light')} className={`flex flex-col items-center justify-center p-3 rounded-lg transition-all ${localTheme === 'light' ? 'bg-accent text-white ring-2 ring-accent' : 'bg-hover'}`}>
                 <Sun size={24} className="mb-1" /><span className="text-xs">فاتح</span>
               </button>
-              <button onClick={() => handleGenericChange(setCurrentTheme, 'dark')} className={`flex flex-col items-center justify-center p-3 rounded-lg transition-all ${localTheme === 'dark' ? 'bg-accent text-white ring-2 ring-accent' : 'bg-hover'}`}>
+              <button onClick={() => handleThemeChange('dark')} className={`flex flex-col items-center justify-center p-3 rounded-lg transition-all ${localTheme === 'dark' ? 'bg-accent text-white ring-2 ring-accent' : 'bg-hover'}`}>
                 <Moon size={24} className="mb-1" /><span className="text-xs">داكن</span>
               </button>
-              <button onClick={() => handleGenericChange(setCurrentTheme, 'green')} className={`flex flex-col items-center justify-center p-3 rounded-lg transition-all ${localTheme === 'green' ? 'bg-accent text-white ring-2 ring-accent' : 'bg-hover'}`}>
+              <button onClick={() => handleThemeChange('green')} className={`flex flex-col items-center justify-center p-3 rounded-lg transition-all ${localTheme === 'green' ? 'bg-accent text-white ring-2 ring-accent' : 'bg-hover'}`}>
                 <Leaf size={24} className="mb-1" /><span className="text-xs">أخضر</span>
               </button>
-              <button onClick={() => handleGenericChange(setCurrentTheme, 'sepia')} className={`flex flex-col items-center justify-center p-3 rounded-lg transition-all ${localTheme === 'sepia' ? 'bg-accent text-white ring-2 ring-accent' : 'bg-hover'}`}>
+              <button onClick={() => handleThemeChange('sepia')} className={`flex flex-col items-center justify-center p-3 rounded-lg transition-all ${localTheme === 'sepia' ? 'bg-accent text-white ring-2 ring-accent' : 'bg-hover'}`}>
                 <BookOpen size={24} className="mb-1" /><span className="text-xs">بني فاتح</span>
               </button>
             </div>


### PR DESCRIPTION
1.  **Settings Save Error and Theme UI:**
    *   Previously, saving settings would show an "Error saving settings" message for unauthenticated users, as the backend mutation requires a user ID. This is fixed by checking for authentication before attempting the database write. Settings are still saved to localStorage for all users to preserve their experience on the current device.
    *   The UI for theme selection was also fixed. It now provides instant visual feedback by applying the theme immediately upon selection, while also correctly highlighting the selected theme button.

2.  **Reciter Not Updating:**
    *   Changing the reciter in settings did not apply the new reciter's audio. This was due to a race condition where the audio playlist was being generated with stale data before the new setting was applied.
    *   This is resolved by adding a `useEffect` hook to the `QuranReader` component. This hook now listens for changes to the settings state and reliably reloads the page data with the correct reciter ID after the state has been updated.