### PR TITLE
fix(build): Correct JSX syntax in StartKhatmahModal

### DIFF
--- a/src/components/StartKhatmahModal.tsx
+++ b/src/components/StartKhatmahModal.tsx
@@ -124,16 +124,14 @@ export function StartKhatmahModal({ onClose, lastPageRead }: StartKhatmahModalPr
                         <span>التالي</span>
                         <ArrowLeft size={18} />
                     </button>
+                ) : isAuthenticated ? (
+                  <button onClick={handleStart} className="px-6 py-2 bg-accent text-white font-bold rounded-lg">
+                    بسم الله، لنبدأ
+                  </button>
                 ) : (
-                    {isAuthenticated ? (
-                      <button onClick={handleStart} className="px-6 py-2 bg-accent text-white font-bold rounded-lg">
-                          بسم الله، لنبدأ
-                      </button>
-                    ) : (
-                      <button className="px-6 py-2 bg-gray-400 text-white font-bold rounded-lg cursor-not-allowed" disabled>
-                          الرجاء تسجيل الدخول أولاً
-                      </button>
-                    )}
+                  <button className="px-6 py-2 bg-gray-400 text-white font-bold rounded-lg cursor-not-allowed" disabled>
+                    الرجاء تسجيل الدخول أولاً
+                  </button>
                 )}
             </div>
         </div>


### PR DESCRIPTION
This commit fixes a build failure caused by a JSX syntax error in the `StartKhatmahModal` component.

An extra set of curly braces `{}` was incorrectly wrapped around a ternary operator, causing the Vite build process to fail. This has been corrected by removing the unnecessary braces.

This resolves the Netlify deployment error and allows the previous bug fixes for the Khatmah modal to be deployed.